### PR TITLE
Fix bug report URL formatting

### DIFF
--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -943,8 +943,10 @@ def formatSeconds(secs, delim=':', msec=False):
 def bug_reports_message(before=';'):
     from ..update import REPOSITORY
 
-    msg = (f'please report this issue on  https://github.com/{REPOSITORY}/issues?q= , '
-           'filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U')
+    msg = (
+        f'please report this issue on https://github.com/{REPOSITORY}/issues, '
+        'filling out the appropriate issue template. Confirm you are on the latest version using yt-dlp -U'
+    )
 
     before = before.rstrip()
     if not before or before.endswith(('.', '!', '?')):


### PR DESCRIPTION
## Summary
- fix the `bug_reports_message` helper to provide a clean GitHub issues link

## Testing
- `ruff check .`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the formatting and clarity of the bug report message shown to users, ensuring correct URL links and instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->