### PR TITLE
Add Gradio example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,17 @@
+# Gradio Example
+
+This folder contains a simple Gradio interface for `yt-dlp`.
+
+The script `gradio_app.py` exposes a minimal web UI where you can
+provide a video URL and optional `yt-dlp` options in JSON format.
+The downloaded video will be returned as a file once processing
+is complete.
+
+Run the application with:
+
+```bash
+python examples/gradio_app.py
+```
+
+The same script can be used on services like Hugging Face Spaces
+to provide an online downloader interface.

--- a/examples/gradio_app.py
+++ b/examples/gradio_app.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+'''Simple Gradio interface for yt-dlp.
+
+This script provides a basic web UI using Gradio to download
+videos using yt-dlp. Provide a video URL and optional yt-dlp
+options in JSON format. The downloaded file will be returned
+for download.
+'''
+
+import json
+import os
+import tempfile
+
+import gradio as gr
+from yt_dlp import YoutubeDL
+
+
+def download_video(url: str, options_json: str | None = None) -> str:
+    """Download video using yt-dlp and return the file path."""
+    ydl_opts = {'outtmpl': os.path.join(tempfile.gettempdir(), '%(title)s.%(ext)s')}
+
+    if options_json:
+        try:
+            ydl_opts.update(json.loads(options_json))
+        except json.JSONDecodeError as err:
+            raise gr.Error(f'Invalid options JSON: {err}')
+
+    with YoutubeDL(ydl_opts) as ydl:
+        info = ydl.extract_info(url, download=True)
+        if 'requested_downloads' in info:
+            file_path = info['requested_downloads'][0]['filepath']
+        else:
+            file_path = ydl.prepare_filename(info)
+    return file_path
+
+
+def main() -> None:
+    gr.Interface(
+        fn=download_video,
+        inputs=[
+            gr.Textbox(label='Video URL'),
+            gr.Textbox(label='yt-dlp options (JSON)', value='{}'),
+        ],
+        outputs=gr.File(label='Downloaded file'),
+        title='yt-dlp Gradio Downloader',
+        description=(
+            'Minimal web interface to run yt-dlp. '
+            'Enter a video URL and optional options in JSON format.'
+        ),
+    ).launch()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `examples/gradio_app.py` as a minimal Gradio interface to run yt-dlp
- document the script in `examples/README.md`

## Testing
- `ruff check --fix examples/gradio_app.py`
- `autopep8 --in-place examples/gradio_app.py examples/README.md` *(fails: command not found)*
- `python -m devscripts.run_tests` *(fails: pytest missing)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a simple web interface for downloading videos using yt-dlp, accessible via a Gradio-powered app.
  - Users can input a video URL and optional yt-dlp options in JSON format to customize downloads.
  - Downloaded videos are returned as files through the web interface.

- **Documentation**
  - Added a README with instructions for running and deploying the new Gradio-based video downloader example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->